### PR TITLE
Change WebpackDevServer from localhost to 0.0.0.0

### DIFF
--- a/dev.js
+++ b/dev.js
@@ -23,7 +23,7 @@ module.exports = function (config, options) {
     stats: 'errors-only'
   })
 
-  server.listen(options.port, 'localhost', function () {
+  server.listen(options.port, '0.0.0.0', function () {
     console.log('webpack-dev-server http://localhost:%d/', options.port)
   })
 }


### PR DESCRIPTION
This allows the dev server to work on a local network. (For iPhone testing on the same network in my case).

Currently, only `localhost` will work, so for example, if you local IP Address is `10.0.3.115` you can't access your project on `10.0.3.115:8000`, but changing WebpackDevServer to listen on `0.0.0.0` fixes this.
