### PR TITLE
Pass publicPath to Webpack dev server

### DIFF
--- a/dev.js
+++ b/dev.js
@@ -13,6 +13,7 @@ module.exports = function (config, options) {
 
   var server = new WebpackDevServer(compiler, {
     contentBase: config.output.path,
+    publicPath: config.output.publicPath,
     historyApiFallback: true,
 
     watchOptions: {


### PR DESCRIPTION
This allows us to have the dev server running on for a subpath instead of the domain.

For example serving on `localhost:8000/example` instead of `localhost:8000`. This makes it run like it would run in the production environment.
