### PR TITLE
Actually use hot module replacement

### DIFF
--- a/dev.js
+++ b/dev.js
@@ -8,6 +8,8 @@ module.exports = function (config, options) {
       new webpack.HotModuleReplacementPlugin()
     ]
   })
+  
+  config.entry = [config.entry, "webpack-dev-server/client?http://localhost:" + options.port + "/", "webpack/hot/dev-server"]
 
   var compiler = webpack(config)
 
@@ -20,7 +22,8 @@ module.exports = function (config, options) {
     },
 
     quiet: options.quiet,
-    stats: 'errors-only'
+    stats: 'errors-only',
+    hot: true
   })
 
   server.listen(options.port, '0.0.0.0', function () {


### PR DESCRIPTION
Don't do a hard refresh when detecting changes during dev mode.
This works for my css needs. I haven't tested it for anything else.
