### PR TITLE
Throw error if it happens in webpack.config.js

### DIFF
--- a/config.js
+++ b/config.js
@@ -224,7 +224,8 @@ module.exports = function (options) {
         'Merging found webpack config %s with reactpack config.',
         path.relative(process.cwd(), webpackConfig)
       ))
-    } catch (e) {
+    } catch (err) {
+      throw err
     }
   }
 


### PR DESCRIPTION
Without this change, syntax errors and other issues in the webpack.config.js would simply lead to the config being ignored. With this change, the error will be thrown instead, so users can see the actual error.
