### PR TITLE
Allow changing the dev server configuration

### DIFF
--- a/dev.js
+++ b/dev.js
@@ -17,7 +17,7 @@ module.exports = function (config, options) {
 
   var compiler = webpack(config)
 
-  var server = new WebpackDevServer(compiler, {
+  var devServerConfig = {
     contentBase: config.output.path,
     historyApiFallback: true,
 
@@ -28,7 +28,13 @@ module.exports = function (config, options) {
     quiet: options.quiet,
     stats: 'errors-only',
     hot: true
-  })
+  }
+
+  if (config.devServer) {
+    devServerConfig = Object.assign(devServerConfig, config.devServer)
+  }
+
+  var server = new WebpackDevServer(compiler, devServerConfig)
 
   server.listen(options.port, '0.0.0.0', function () {
     console.log('webpack-dev-server http://0.0.0.0:%d/', options.port)


### PR DESCRIPTION
I was spending around one hour trying to troubleshot why my devServer config in webpack.config.js didn't work. Turns out, those options are not applied when starting the dev server.

This change implements so it's possible to customize the dev server, if the devServer key is set in the webpack.config.js
